### PR TITLE
Fixing group_by with multiple ids

### DIFF
--- a/lib/rql/query_parser.ex
+++ b/lib/rql/query_parser.ex
@@ -218,7 +218,8 @@ defmodule Ravix.RQL.QueryParser do
   end
 
   defp parse_group_by(%Query{} = query, group_by_token) do
-    query_fragment = " group by " <> Enum.map_join(group_by_token.fields, &parse_field(query, &1))
+    query_fragment =
+      " group by " <> Enum.map_join(group_by_token.fields, ", ", &parse_field(query, &1))
 
     {:ok, append_query_fragment(query, query_fragment)}
   end

--- a/test/operations/database_maintenance_test.exs
+++ b/test/operations/database_maintenance_test.exs
@@ -26,7 +26,7 @@ defmodule Ravix.Operations.Database.MaintenanceTest do
       {:ok, _created} = Maintenance.create_database(NonRetryableStore, db_name)
       {:error, err} = Maintenance.create_database(NonRetryableStore, db_name)
 
-      assert err == "Database '#{db_name}' already exists!"
+      assert err == :conflict
     end
   end
 

--- a/test/rql/query_test.exs
+++ b/test/rql/query_test.exs
@@ -288,6 +288,8 @@ defmodule Ravix.RQL.QueryTest do
         |> Enum.sort_by(fn cat -> String.first(cat.name) end)
         |> Enum.at(0)
 
+      :timer.sleep(200)
+
       assert found_cat["name"] == sorted_cat.name
       assert found_cat["breed"] == sorted_cat.breed
     end
@@ -349,7 +351,7 @@ defmodule Ravix.RQL.QueryTest do
 
           query_response <-
             from("Cats")
-            |> group_by("breed")
+            |> group_by(["breed", "registry"])
             |> where(equal_to("breed", cat.breed))
             |> list_all(session_id)
         after

--- a/test/support/cat.ex
+++ b/test/support/cat.ex
@@ -1,4 +1,4 @@
 defmodule Ravix.SampleModel.Cat do
   @moduledoc false
-  use Ravix.Document, fields: [:id, :name, :breed]
+  use Ravix.Document, fields: [:id, :name, :breed, :registry]
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -33,7 +33,8 @@ defmodule Ravix.Factory do
     %Cat{
       id: UUID.uuid4(),
       name: Faker.Cat.name(),
-      breed: Faker.Cat.breed()
+      breed: Faker.Cat.breed(),
+      registry: Faker.Cat.registry()
     }
   end
 end


### PR DESCRIPTION
The parser for group by with multiple parameters was broken