### PR TITLE
[patch] Reconnect connections if they are closed

### DIFF
--- a/lib/connection/executor/request_executor.ex
+++ b/lib/connection/executor/request_executor.ex
@@ -391,7 +391,7 @@ defmodule Ravix.Connection.RequestExecutor do
 
     case Mint.HTTP.connect(node.protocol, node.url, node.port, conn_params) do
       {:ok, conn} ->
-        Logger.info(
+        Logger.debug(
           "[RAVIX] Connected to node '#{inspect(node.url)}' for store '#{inspect(node.store)}'"
         )
 


### PR DESCRIPTION
HTTP connections are not persistent and mint does not reconnect automagically, so if the conn is closed in a request, jut reopen it.

