### PR TITLE
fix: add missing inspect

### DIFF
--- a/lib/connection/executor/supervisor.ex
+++ b/lib/connection/executor/supervisor.ex
@@ -109,7 +109,7 @@ defmodule Ravix.Connection.RequestExecutor.Supervisor do
       RequestExecutor.Supervisor.remove_node_pool(store, pid)
     end)
 
-    Logger.info("[RAVIX] Unregistering the nodes '#{nodes_to_delete}'")
+    Logger.info("[RAVIX] Unregistering the nodes '#{inspect(nodes_to_delete)}'")
 
     current_nodes -- nodes_to_delete
   end


### PR DESCRIPTION
There was a missing inspect call in the string interpolation in the supervisor startup. 

Added it 😄 