### PR TITLE
chore: Partition Supervisors

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -113,4 +113,4 @@ config :ravix, Ravix.Test.RandomStore,
     disable_topology_update: false
   }
 
-config :logger, level: :error
+config :logger, level: :emergency

--- a/lib/connection/executor/request_executor.ex
+++ b/lib/connection/executor/request_executor.ex
@@ -22,8 +22,8 @@ defmodule Ravix.Connection.RequestExecutor do
     end
   end
 
-  @spec start_link(any, ServerNode.t()) :: :ignore | {:error, any} | {:ok, pid}
-  def start_link(_attrs, %ServerNode{} = node) do
+  @spec start_link(ServerNode.t()) :: :ignore | {:error, any} | {:ok, pid}
+  def start_link(%ServerNode{} = node) do
     GenServer.start_link(
       __MODULE__,
       node,

--- a/lib/connection/executor/supervisor.ex
+++ b/lib/connection/executor/supervisor.ex
@@ -77,7 +77,7 @@ defmodule Ravix.Connection.RequestExecutor.Supervisor do
     )
 
     DynamicSupervisor.terminate_child(
-      {:via, PartitionSupervisor, {supervisor_name(node.store), node.url}},
+      {:via, PartitionSupervisor, {supervisor_name(node.store), ServerNode.node_id(node)}},
       pid
     )
   end

--- a/lib/connection/models/server_node.ex
+++ b/lib/connection/models/server_node.ex
@@ -63,6 +63,12 @@ defmodule Ravix.Connection.ServerNode do
     }
   end
 
+  def node_id(%ServerNode{} = server_node),
+    do:
+      :crypto.hash(:sha256, server_node.url <> server_node.database)
+      |> Base.encode16()
+      |> String.downcase()
+
   @doc """
     Helper method to build the base path for Database specific API requests
   """

--- a/lib/documents/session/supervisor.ex
+++ b/lib/documents/session/supervisor.ex
@@ -22,7 +22,8 @@ defmodule Ravix.Documents.Session.Supervisor do
     session_state = session_state |> SessionState.update_last_session_call()
 
     DynamicSupervisor.start_child(
-      {:via, PartitionSupervisor, {supervisor_name(session_state.store), session_state.session_id}},
+      {:via, PartitionSupervisor,
+       {supervisor_name(session_state.store), session_state.session_id}},
       {Session, session_state}
     )
   end

--- a/lib/documents/session/supervisor.ex
+++ b/lib/documents/session/supervisor.ex
@@ -2,21 +2,16 @@ defmodule Ravix.Documents.Session.Supervisor do
   @moduledoc """
   Supervisor for RavenDB Sessions
   """
-  use DynamicSupervisor
-
   alias Ravix.Documents.Session
   alias Ravix.Documents.Session.State, as: SessionState
 
-  def init(init_arg) do
-    DynamicSupervisor.init(
-      strategy: :one_for_one,
-      extra_arguments: [init_arg]
-    )
-  end
-
   @spec start_link(any) :: :ignore | {:error, any} | {:ok, pid}
   def start_link(store) do
-    DynamicSupervisor.start_link(__MODULE__, %{}, name: supervisor_name(store))
+    children = [
+      {PartitionSupervisor, child_spec: DynamicSupervisor, name: supervisor_name(store)}
+    ]
+
+    Supervisor.start_link(children, strategy: :one_for_one)
   end
 
   @doc """
@@ -25,17 +20,17 @@ defmodule Ravix.Documents.Session.Supervisor do
   @spec create_session(SessionState.t()) :: :ignore | {:error, any} | {:ok, pid} | {:ok, pid, any}
   def create_session(%SessionState{} = session_state) do
     session_state = session_state |> SessionState.update_last_session_call()
-    DynamicSupervisor.start_child(supervisor_name(session_state.store), {Session, session_state})
+
+    DynamicSupervisor.start_child(
+      {:via, PartitionSupervisor, {supervisor_name(session_state.store), session_state.session_id}},
+      {Session, session_state}
+    )
   end
 
   @doc """
   Closes a session for the informed store using the session pid or session_id
   """
-  @spec close_session(atom(), pid | bitstring()) :: :ok | {:error, :not_found}
-  def close_session(store, pid) when is_pid(pid) do
-    DynamicSupervisor.terminate_child(supervisor_name(store), pid)
-  end
-
+  @spec close_session(atom(), bitstring()) :: :ok | {:error, :not_found}
   def close_session(store, session_id) do
     case Registry.lookup(:sessions, session_id) do
       [] ->
@@ -43,7 +38,11 @@ defmodule Ravix.Documents.Session.Supervisor do
 
       sessions ->
         {pid, _} = sessions |> Enum.at(0)
-        DynamicSupervisor.terminate_child(supervisor_name(store), pid)
+
+        DynamicSupervisor.terminate_child(
+          {:via, PartitionSupervisor, {supervisor_name(store), session_id}},
+          pid
+        )
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Ravix.MixProject do
     [
       app: :ravix,
       version: "0.7.0",
-      elixir: "~> 1.13",
+      elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),


### PR DESCRIPTION
- This leverages the use of [PartitionSupervisors](https://hexdocs.pm/elixir/main/PartitionSupervisor.html) from Elixir 1.14, improving the parallelism for the executors and sessions.
- With this change, we can have multiple supervisors per session and per nodes.